### PR TITLE
fixed the bug about video_demo/requirements.txt

### DIFF
--- a/video_demo/requirements.txt
+++ b/video_demo/requirements.txt
@@ -4,7 +4,7 @@ torch==2.1.0
 torchvision== 0.16.0
 pytorchvideo==0.1.5
 xformers
-transformers==4.42.4
+transformers==4.42.0
 #如果运行提示transformers错误，则可能是transformers代码问题，拉取最新的试下
 #git+https://github.com/huggingface/transformers.git
 huggingface-hub>=0.23.0


### PR DESCRIPTION
transformers 使用 4.42.2 会报错：ValueError: too many values to unpack (expected 2)
推测是 pytorch 版本更新导致，更改 transformers 版本为 4.40.2 即可修复该错误